### PR TITLE
動画がアップロードされたかチェックする機能の実装

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -74,14 +74,11 @@ func YoutubeChannelSectionsHandler(w http.ResponseWriter, r *http.Request) {
     }
 
 	ctx := context.Background()
-	uploadList, err := CheckUploadVideos(ctx)
+	err := CheckUploadVideos(ctx)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
-	}
-	for _, list := range uploadList {
-		log.Printf("youtube-channel-sections: channelId = %s\n", list.channelId)
 	}
 	w.Write([]byte("Youtube Channel Sections OK"))
 }


### PR DESCRIPTION
- sectionsテーブルを作成した。
- Youtube Data API にリクエストを飛ばし、特定のチャンネルから動画がアップロードされたことを検知した場合、DBのsectionsテーブルにIDとチャンネルID、カラム作成日を保存するようにした。