### PR TITLE
検索クエリを2種類使うように変更&いらない機能を削除

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -16,20 +16,24 @@ func YoutubeHandler(w http.ResponseWriter, r *http.Request) {
     }
 
 	ctx := context.Background()
-	videoId, err := YoutubeSearchList(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
-		return
-	}
 
-	fmt.Printf("videoId=%s\n", videoId)
+	for _, q := range []string{"にじさんじ 歌", "にじさんじ 歌ってみた"} {
+		videoId, err := YoutubeSearchList(ctx, q)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
 
-	err = YoutubeVideoList(ctx, videoId)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
-		return
+		// 検索にヒットした動画IDをログに出力
+		fmt.Printf("videoId=%s\n", videoId)
+
+		err = YoutubeVideoList(ctx, videoId)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
 	}
 	w.Write([]byte("Youtube OK"))
 }
@@ -64,21 +68,4 @@ func TwitterHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.Write([]byte("Twitter OK"))
-}
-
-func YoutubeChannelSectionsHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-        w.WriteHeader(http.StatusMethodNotAllowed) // 405
-        w.Write([]byte("POSTだけだよ"))
-        return
-    }
-
-	ctx := context.Background()
-	err := CheckUploadVideos(ctx)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
-		return
-	}
-	w.Write([]byte("Youtube Channel Sections OK"))
 }

--- a/main.go
+++ b/main.go
@@ -27,16 +27,12 @@ func main() {
 	DBInit()
 
 	h1 := func(w http.ResponseWriter, _ *http.Request) {
-		io.WriteString(w, "Hello from a HandleFunc #1!!!\n")
+		io.WriteString(w, "pong\n")
 	}
 
-	http.HandleFunc("/", h1)
+	http.HandleFunc("/ping", h1)
 	http.HandleFunc("/youtube", YoutubeHandler)
 	http.HandleFunc("/twitter", TwitterHandler)
-	http.HandleFunc("/youtube/sections", YoutubeChannelSectionsHandler)
-
-	// http.HandleFunc("/seed", Seed) // Seed
-	// http.HandleFunc("/seedOut", SeedOut) // Seed
 
 	log.Printf("listening on port %s", port)
 	// Start HTTP server.


### PR DESCRIPTION
### やったこと
- `にじさんじ 歌`と`にじさんじ 歌ってみた`の2種類のクエリを使ってYoutube Data API seach listにリクエストを送るように変更した
- Youtube Data API Sections を試しに使ってみたが、仕様を勘違いしており、最新動画の情報を取得することができなかったため、その部分のロジックやハンドラ処理を削除した