### PR TITLE
検索クエリの変更

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,7 @@ func YoutubeHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := context.Background()
 
-	for _, q := range []string{"にじさんじ 歌", "にじさんじ 歌ってみた"} {
+	for _, q := range []string{"にじさんじ", "NIJISANJI"} {
 		videoId, err := YoutubeSearchList(ctx, q)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/model.go
+++ b/model.go
@@ -42,17 +42,18 @@ func YoutubeSearchList(ctx context.Context, q string) (string, error) {
 	dtAfter := time.Now().UTC().Add(-30 * time.Minute).Format("2006-01-02T15:04:00Z")
 	dtBefore := time.Now().UTC().Format("2006-01-02T15:04:00Z")
 
-	log.Printf("youtube-search-list: %s ~ %s\n", dtAfter, dtBefore)
-
 	searchCall := youtubeService.Search.List([]string{"id"}).
-		MaxResults(50).
-		Q(q).
-		PublishedAfter(dtAfter).
-		PublishedBefore(dtBefore)
+	MaxResults(50).
+	Q(q).
+	PublishedAfter(dtAfter).
+	PublishedBefore(dtBefore)
 	searchRes, err := searchCall.Do()
 	if err != nil {
 		return "", err
 	}
+
+	log.Printf("youtube-search-list: %s ~ %s item: %d\n", dtAfter, dtBefore,searchRes.PageInfo.ResultsPerPage)
+
 	// これもっといいロジックがある https://qiita.com/ono_matope/items/d5e70d8a9ff2b54d5c37
 	videoId := ""
 	for _, searchItem := range searchRes.Items {


### PR DESCRIPTION
### やったこと
- Youtube Data API search list にリクエストを飛ばす時の検索クエリの変更をおこなった
  - `にじさんじ 歌`と`にじさんじ 歌ってみた` から `にじさんじ` と `NIJISANJI` に変更した
- search list のレスポンス `pageInfo.resultsPerPage` をログに出力するようにした
### 今後
しばらくこれで運用してログを確認し、`pageInfo.resultsPerPage` が `50` を出力し続けている場合、検索クエリの変更やAPIを叩く頻度を短くしたりする