### PR TITLE
検索結果が50を超えても、超えた分も取得できるようにした

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -10,31 +8,25 @@ import (
 
 func YoutubeHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-        w.WriteHeader(http.StatusMethodNotAllowed) // 405
-        w.Write([]byte("POSTだけだよ"))
-        return
-    }
-
-	ctx := context.Background()
-
-	for _, q := range []string{"にじさんじ", "NIJISANJI"} {
-		videoId, err := YoutubeSearchList(ctx, q)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-
-		// 検索にヒットした動画IDをログに出力
-		fmt.Printf("videoId=%s\n", videoId)
-
-		err = YoutubeVideoList(ctx, videoId)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
+		w.WriteHeader(http.StatusMethodNotAllowed) // 405
+		w.Write([]byte("POSTだけだよ"))
+		return
 	}
+
+	vid, err := YoutubeSearchList()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	err = YoutubeVideoList(vid)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
 	w.Write([]byte("Youtube OK"))
 }
 
@@ -42,10 +34,10 @@ const endpoint = "https://api.twitter.com/2/tweets"
 
 func TwitterHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-        w.WriteHeader(http.StatusMethodNotAllowed)
-        w.Write([]byte("POSTだけだよ"))
-        return
-    }
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("POSTだけだよ"))
+		return
+	}
 	dtAfter := time.Now().UTC().Format("2006-01-02 15:04:05")
 	dtBefore := time.Now().UTC().Add(5 * time.Minute).Format("2006-01-02 15:04:00")
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
 	"io"
 	"log"
 	"net/http"
 	"os"
 
 	"github.com/joho/godotenv"
+	"google.golang.org/api/option"
+	"google.golang.org/api/youtube/v3"
 )
+
+var YoutubeService *youtube.Service
 
 func main() {
 	log.Print("starting server...")
@@ -21,6 +26,12 @@ func main() {
 	if port == "" {
 		port = "8080"
 		log.Printf("defaulting to port %s", port)
+	}
+
+	ctx := context.Background()
+	YoutubeService, err = youtube.NewService(ctx, option.WithAPIKey(os.Getenv("YOUTUBE_API_KEY")))
+	if err != nil {
+		log.Printf("Error youtube.NewService")
 	}
 
 	// DB接続初期化


### PR DESCRIPTION
## やったこと
### 検索結果が50を超えても、その分も取得できるようにした
 Youtube Data API Search List で検索結果が50を超える場合がある。その時はクエリパラメーターの`pageToken`を指定しないと、超えた分のレスポンスを取得することができない。
そのため、50を超えるレスポンスデータに含まれる`nextPageToken`を、再びリクエストを送るときの`pageToken`に指定するように実装した
 ### リファクタ
ctxとYoutubeServiceをmain.goで定義するように変更した