### PR TITLE
リダイレクト先URLを取得した時にログを出力するように変更した

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -204,6 +204,8 @@ func tweetSelect(gtc []GetTweetContext) ([]TwitterSearchResponse, error) {
 		// Redirect先のURLを取得
 		rid := resp.Header.Get("Location")
 
+		clog.Str("severity", "INFO").Str("redirect_url", rid).Send()
+
 		// URLからYouTubeの動画ID部分を抽出する
 		var yid string
 		idx = strings.Index(rid, "youtu.be")
@@ -219,7 +221,7 @@ func tweetSelect(gtc []GetTweetContext) ([]TwitterSearchResponse, error) {
 		}
 
 		tsr = append(tsr, TwitterSearchResponse{ID: v.ID, YouTubeID: yid, Text: v.Text})
-		clog.Str("severity", "INFO").Str("youtube_id", yid).Send()
+		// clog.Str("severity", "INFO").Str("youtube_id", yid).Str("youtube_url", rid).Send()
 	}
 	return tsr, nil
 }


### PR DESCRIPTION
220行目でエラーが発生することがあるため原因解明のためログ出力するタイミングを変更した