### PR TITLE
220行でエラーが発生していたのを修正

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -217,6 +217,11 @@ func tweetSelect(gtc []GetTweetContext) ([]TwitterSearchResponse, error) {
 			if idx == -1 {
 				continue
 			}
+			// ショート動画であった場合
+			idx = strings.Index(rid, "youtube.com/shorts")
+			if idx != -1 {
+				continue
+			}
 			yid = rid[32:43]
 		}
 


### PR DESCRIPTION
Cloud Logging を確認したところ、
短縮URLからリダイレクト先のURLを取得した後、URLがショート動画のリンクであった場合の処理をしていなかったため、エラーが発生したと考えられる。そのため、リダイレクト先URLがショート動画の場合、continueすることにした。