### PR TITLE
getURL関数の作成

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -239,6 +239,15 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 
 	// 歌動画か判断する
 	for _, video := range res.Items {
+		log.Info().
+			Str("severity", "INFO").
+			Str("service", "twitter-select").
+			Str("twitter_id", yttw[video.Id]).
+			Str("id", video.Id).
+			Str("title", video.Snippet.Title).
+			Str("duration", video.ContentDetails.Duration).
+			Str("schedule", video.LiveStreamingDetails.ScheduledStartTime).
+			Send()
 		// プレミア公開する動画か
 		scheduledStartTime := "" // 例 2022-03-28T11:00:00Z
 		if video.LiveStreamingDetails != nil {
@@ -279,16 +288,7 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 			continue
 		}
 
-		ytcr = append(ytcr, YouTubeCheckResponse{ID: video.Id, Title: video.Snippet.Title, Schedule: video.LiveStreamingDetails.ScheduledStartTime, TwitterID: yttw[video.Id]})
-
-		log.Info().
-			Str("severity", "INFO").
-			Str("service", "youtube-video-check").
-			Str("id", video.Id).
-			Str("title", video.Snippet.Title).
-			Str("duration", video.ContentDetails.Duration).
-			Str("schedule", scheduledStartTime).
-			Send()
+		ytcr = append(ytcr, YouTubeCheckResponse{ID: video.Id, Title: video.Snippet.Title, Schedule: scheduledStartTime, TwitterID: yttw[video.Id]})
 	}
 	return ytcr, nil
 }

--- a/twitter.go
+++ b/twitter.go
@@ -85,12 +85,6 @@ type TwitterSearchResponse struct {
 	Text      string `json:"text"`
 }
 
-var clint = &http.Client{
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
-}
-
 // Searchで使用するカスタムエラーログ
 var twlog = log.Info().Str("service", "twitter-search").Str("severity", "ERROR")
 
@@ -232,6 +226,9 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 	}
 	// にじさんじライバーのチャンネルリストを取得
 	channelIdList, err := GetChannelIdList()
+	if (err != nil) {
+		log.Info().Str("service", "twitter-select").Str("severity", "ERROR").Msg(err.Error())
+	}
 
 	call := YoutubeService.Videos.List([]string{"snippet", "contentDetails", "liveStreamingDetails"}).Id(strings.Join(id, ",")).MaxResults(50)
 	res, err := call.Do()

--- a/twitter.go
+++ b/twitter.go
@@ -27,49 +27,51 @@ type PostTweetContext struct {
 }
 
 type GetTweetContext struct {
-	ID       string `json:"id"`
-	Text     string `json:"text"`
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
+
+type ListTweetsEntities struct {
+	Annotations []struct {
+		Start          int     `json:"start"`
+		End            int     `json:"end"`
+		Probability    float64 `json:"probability"`
+		Type           string  `json:"type"`
+		NormalizedText string  `json:"normalized_text"`
+	} `json:"annotations"`
+	Cashtags []struct {
+		Start int    `json:"start"`
+		End   int    `json:"end"`
+		Tag   string `json:"tag"`
+	} `json:"cashtags"`
+	Hashtags []struct {
+		Start int    `json:"start"`
+		End   int    `json:"end"`
+		Tag   string `json:"tag"`
+	} `json:"hashtags"`
+	Mentions []struct {
+		Start int    `json:"start"`
+		End   int    `json:"end"`
+		Tag   string `json:"tag"`
+	} `json:"mentions"`
+	Urls []struct {
+		Start       int    `json:"start"`
+		End         int    `json:"end"`
+		URL         string `json:"url"`
+		ExpandedURL string `json:"expanded_url"`
+		DisplayURL  string `json:"display_url"`
+		Status      string `json:"status"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		UnwoundURL  string `json:"unwound_url"`
+	} `json:"urls"`
 }
 
 type ListTweetsResponse struct {
 	Data []struct {
-		Entities struct {
-			Annotations []struct {
-				Start          int     `json:"start"`
-				End            int     `json:"end"`
-				Probability    float64 `json:"probability"`
-				Type           string  `json:"type"`
-				NormalizedText string  `json:"normalized_text"`
-			} `json:"annotations"`
-			Cashtags []struct {
-				Start int    `json:"start"`
-				End   int    `json:"end"`
-				Tag   string `json:"tag"`
-			} `json:"cashtags"`
-			Hashtags []struct {
-				Start int    `json:"start"`
-				End   int    `json:"end"`
-				Tag   string `json:"tag"`
-			} `json:"hashtags"`
-			Mentions []struct {
-				Start int    `json:"start"`
-				End   int    `json:"end"`
-				Tag   string `json:"tag"`
-			} `json:"mentions"`
-			Urls []struct {
-				Start       int    `json:"start"`
-				End         int    `json:"end"`
-				URL         string `json:"url"`
-				ExpandedURL string `json:"expanded_url"`
-				DisplayURL  string `json:"display_url"`
-				Status      string `json:"status"`
-				Title       string `json:"title"`
-				Description string `json:"description"`
-				UnwoundURL  string `json:"unwound_url"`
-			} `json:"urls"`
-		} `json:"entities"`
-		ID   string `json:"id"`
-		Text string `json:"text"`
+		Entities ListTweetsEntities `json:"entities"`
+		ID       string             `json:"id"`
+		Text     string             `json:"text"`
 	} `json:"data"`
 	Meta struct {
 		ResultCount int    `json:"result_count"`
@@ -91,6 +93,7 @@ var clint = &http.Client{
 
 // Searchで使用するカスタムエラーログ
 var twlog = log.Info().Str("service", "twitter-search").Str("severity", "ERROR")
+
 // getRedirectで使用するカスタムエラーログ
 var tgrlog = log.Info().Str("service", "twitter-getRedirect").Str("severity", "ERROR")
 
@@ -340,3 +343,5 @@ func getRedirect(id string, text string) (string, error) {
 	// youtube動画のリンクでなかった場合
 	return "", nil
 }
+
+func getUrl()

--- a/twitter.go
+++ b/twitter.go
@@ -27,21 +27,50 @@ type PostTweetContext struct {
 }
 
 type GetTweetContext struct {
-	AuthorID string `json:"author_id"`
 	ID       string `json:"id"`
 	Text     string `json:"text"`
 }
 
-type ListsResponse struct {
-	Data     []GetTweetContext `json:"data"`
-	Includes struct {
-		Users []struct {
-			CreatedAt time.Time `json:"created_at"`
-			ID        string    `json:"id"`
-			Name      string    `json:"name"`
-			Username  string    `json:"username"`
-		} `json:"users"`
-	} `json:"includes"`
+type ListTweetsResponse struct {
+	Data []struct {
+		Entities struct {
+			Annotations []struct {
+				Start          int     `json:"start"`
+				End            int     `json:"end"`
+				Probability    float64 `json:"probability"`
+				Type           string  `json:"type"`
+				NormalizedText string  `json:"normalized_text"`
+			} `json:"annotations"`
+			Cashtags []struct {
+				Start int    `json:"start"`
+				End   int    `json:"end"`
+				Tag   string `json:"tag"`
+			} `json:"cashtags"`
+			Hashtags []struct {
+				Start int    `json:"start"`
+				End   int    `json:"end"`
+				Tag   string `json:"tag"`
+			} `json:"hashtags"`
+			Mentions []struct {
+				Start int    `json:"start"`
+				End   int    `json:"end"`
+				Tag   string `json:"tag"`
+			} `json:"mentions"`
+			Urls []struct {
+				Start       int    `json:"start"`
+				End         int    `json:"end"`
+				URL         string `json:"url"`
+				ExpandedURL string `json:"expanded_url"`
+				DisplayURL  string `json:"display_url"`
+				Status      string `json:"status"`
+				Title       string `json:"title"`
+				Description string `json:"description"`
+				UnwoundURL  string `json:"unwound_url"`
+			} `json:"urls"`
+		} `json:"entities"`
+		ID   string `json:"id"`
+		Text string `json:"text"`
+	} `json:"data"`
 	Meta struct {
 		ResultCount int    `json:"result_count"`
 		NextToken   string `json:"next_token"`
@@ -141,7 +170,7 @@ func (tw *Twitter) Post(id string, text string) error {
 
 // にじさんじライバーのツイートを取得する
 func (tw *Twitter) Search() ([]TwitterSearchResponse, error) {
-	endpoint := "https://api.twitter.com/2/lists/1538799448679395328/tweets?expansions=author_id&user.fields=created_at&max_results=30"
+	endpoint := "https://api.twitter.com/2/lists/1538799448679395328/tweets?tweet.fields=entities&expansions=referenced_tweets.id&max_results=30"
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
@@ -165,7 +194,7 @@ func (tw *Twitter) Search() ([]TwitterSearchResponse, error) {
 		return nil, err
 	}
 
-	var gtc ListsResponse
+	var gtc ListTweetsResponse
 	if err := json.Unmarshal(body, &gtc); err != nil {
 		twlog.Msg(err.Error())
 		return nil, err

--- a/twitter.go
+++ b/twitter.go
@@ -214,11 +214,7 @@ func (tw *Twitter) Search() ([]TwitterSearchResponse, error) {
 			}
 		}
 
-		yid, err := getRedirect(tweet.ID, tweet.Text)
-		if err != nil {
-			twlog.Msg(err.Error())
-			return nil, err
-		}
+		yid := getUrl(tweet.Entities)
 		if yid != "" {
 			tsr = append(tsr, TwitterSearchResponse{ID: tweet.ID, YouTubeID: yid, Text: tweet.Text})
 		}
@@ -344,4 +340,16 @@ func getRedirect(id string, text string) (string, error) {
 	return "", nil
 }
 
-func getUrl()
+// ツイート内容からURLを取得する
+// Youtube動画リンクではない場合は""を返す
+func getUrl(entities ListTweetsEntities) string {
+	if entities.Urls == nil {
+		return ""
+	}
+	for _, url := range entities.Urls {
+		if (strings.Contains(url.ExpandedURL, "youtu.be") || strings.Contains(url.ExpandedURL, "youtube.com/watch")) {
+			return url.ExpandedURL
+		}
+	}
+	return ""
+}

--- a/twitter.go
+++ b/twitter.go
@@ -207,6 +207,14 @@ func (tw *Twitter) Search() ([]TwitterSearchResponse, error) {
 
 		yid := getUrl(tweet.Entities)
 		if yid != "" {
+			// ツイートに"公開"の文字列が含まれていないが、YouTubeのリンクが含まれていた場合、メールの送信
+			if !strings.Contains(tweet.Text, "公開") {
+				err := sendMail(tweet.ID, tweet.Text)
+				if err != nil {
+					twlog.Msg(err.Error())
+					return nil, err
+				}
+			}
 			tsr = append(tsr, TwitterSearchResponse{ID: tweet.ID, YouTubeID: yid, Text: tweet.Text})
 		}
 	}


### PR DESCRIPTION
- Twitter API list tweetsのクエリパラメーターを変更したため、リダイレクト先URLを取得する処理が必要なくなったため、リダイレクト先URLを取得する処理を削除した。
- 削除した代わりに、TwitterAPI レスポンスからURLを取得するgetURL関数の実装をした。
- その他諸々のバグを修正
