### PR TITLE
GetChannelIdList()取得失敗時のエラーログの修正&select()のエラー表示するタイミングの変更

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -250,7 +250,7 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 	// にじさんじライバーのチャンネルリストを取得
 	channelIdList, err := GetChannelIdList()
 	if err != nil {
-		log.Info().Str("service", "twitter-select").Str("severity", "ERROR").Msg(err.Error())
+		log.Info().Str("service", "twitter-select").Str("severity", "ERROR").Msg("GetChannelIdList() error")
 	}
 
 	call := YoutubeService.Videos.List([]string{"snippet", "contentDetails", "liveStreamingDetails"}).Id(strings.Join(id, ",")).MaxResults(50)
@@ -262,15 +262,6 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 
 	// 歌動画か判断する
 	for _, video := range res.Items {
-		log.Info().
-			Str("severity", "INFO").
-			Str("service", "twitter-select").
-			Str("twitter_id", yttw[video.Id]).
-			Str("id", video.Id).
-			Str("title", video.Snippet.Title).
-			Str("duration", video.ContentDetails.Duration).
-			Str("schedule", video.LiveStreamingDetails.ScheduledStartTime).
-			Send()
 		// プレミア公開する動画か
 		scheduledStartTime := "" // 例 2022-03-28T11:00:00Z
 		if video.LiveStreamingDetails != nil {
@@ -310,6 +301,17 @@ func (tw *Twitter) Select(tsr []TwitterSearchResponse) ([]YouTubeCheckResponse, 
 		if !NijisanjiCheck(channelIdList, video.Snippet.ChannelId) {
 			continue
 		}
+
+		// フィルターをくくり抜けたデータのみログを表示
+		log.Info().
+			Str("severity", "INFO").
+			Str("service", "twitter-select").
+			Str("twitter_id", yttw[video.Id]).
+			Str("id", video.Id).
+			Str("title", video.Snippet.Title).
+			Str("duration", video.ContentDetails.Duration).
+			Str("schedule", video.LiveStreamingDetails.ScheduledStartTime).
+			Send()
 
 		ytcr = append(ytcr, YouTubeCheckResponse{ID: video.Id, Title: video.Snippet.Title, Schedule: scheduledStartTime, TwitterID: yttw[video.Id]})
 	}


### PR DESCRIPTION
- GetChannelIdList()取得失敗時のエラーログを分かりやすいように修正
- selectはフィルターをくぐり抜けたデータのみをログ表示するように修正