### PR TITLE
メール送信する際の条件の変更、メール本文にツイートURLの追加

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func sendMail(subject, message string) error {
+func sendMail(tid string, subject string, message string) error {
     auth := smtp.PlainAuth(
         "",
         "aopontan0416@gmail.com", // 送信に使うアカウント
@@ -22,6 +22,8 @@ func sendMail(subject, message string) error {
             "To: aopontan0416@gmail.com\r\n" +
             "Subject:" + subject + "\r\n" +
             "\r\n" +
-            message),
+            message + "\r\n" +
+            "\r\n" +
+            "Tweet URL: https://twitter.com/demo/status/" + tid + "\r\n"),
     )
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	send := func(w http.ResponseWriter, _ *http.Request) {
-		sendMail("test", "test2-message")
+		sendMail("id001", "test-subject", "test2-message")
 		io.WriteString(w, "send-demo\n")
 	}
 

--- a/twitter.go
+++ b/twitter.go
@@ -334,9 +334,9 @@ func tweetsFilter(ltd []ListTweetsData) []ListTweetsData {
 func (tw *Twitter) Mail(tsr []TwitterSearchResponse) error {
 	clog := log.Error().Str("severity", "ERROR").Str("service", "twitter-mail")
 	for _, t := range tsr {
-		// ツイート内容に"公開"の文字が含まれているかつ動画リンクがない場合、メールを送る
-		if strings.Contains(t.Text, "公開") && t.YoutubeData == nil {
-			err := sendMail(t.ID, t.Text)
+		// ツイート内容に"プレミア公開"の文字が含まれているかつ動画リンクがない場合、メールを送る
+		if strings.Contains(t.Text, "プレミア公開") && t.YoutubeData == nil {
+			err := sendMail(t.ID, "動画リンクない告知", t.Text)
 			if err != nil {
 				clog.Str("id", t.ID).Str("text", t.Text).Msg(err.Error())
 				return err
@@ -363,7 +363,7 @@ func (tw *Twitter) Mail(tsr []TwitterSearchResponse) error {
 			continue
 		}
 		// ツイートIDとツイート内容をメールの送信
-		err := sendMail(t.ID, t.Text)
+		err := sendMail(t.ID, "動画リンクあり告知", t.Text)
 		if err != nil {
 			clog.Str("id", t.ID).Str("text", t.Text).Msg(err.Error())
 			return err


### PR DESCRIPTION
### 変更点
- [ツイート本文に"プレミア公開"の文字が含まれているかつ動画リンクがない場合メール送信するように変更](https://github.com/aopontann/nijisanji-songs-announcement/commit/bd5db6c8f0fa47d5286cb9eb173745e4270316ab)
- [送信するメール本文にツイートURLを含めるように変更](https://github.com/aopontann/nijisanji-songs-announcement/commit/227ad9ed6ddace62cc31333ae0b07f7f4e126118)
- [sendMail関数の引数を変更したための修正](https://github.com/aopontann/nijisanji-songs-announcement/commit/c20ecad6a6e66ca4e98144853f35f18577fa6cbd)